### PR TITLE
Add tests for utility and dataframe functions

### DIFF
--- a/china_data/tests/test_dataframe_ops.py
+++ b/china_data/tests/test_dataframe_ops.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from china_data.utils.processor_dataframe import merge_dataframe_column, merge_projections, merge_tax_data
+from china_data.utils.processor_dataframe import prepare_final_dataframe
+
+
+def test_merge_dataframe_column_adds_values():
+    tgt = pd.DataFrame({'year':[2000,2001]})
+    src = pd.DataFrame({'year':[2000,2001],'col':[1,2]})
+    out, count = merge_dataframe_column(tgt, src, 'col', 'test')
+    assert count == 2
+    assert list(out['col']) == [1,2]
+
+
+def test_merge_dataframe_column_missing_source():
+    tgt = pd.DataFrame({'year':[2000,2001]})
+    src = pd.DataFrame({'year':[2000,2001]})
+    out, count = merge_dataframe_column(tgt, src, 'col', 'test')
+    assert count == 0
+    assert out['col'].isna().all()
+
+
+def test_merge_projections_applies_projection():
+    tgt = pd.DataFrame({'year':[2020,2021],'val':[1.0,None]})
+    proj = pd.DataFrame({'year':[2021],'val':[2.0]})
+    out, meta = merge_projections(tgt, proj, 'val', 'method', 'val')
+    assert out.loc[out['year']==2021,'val'].iloc[0] == 2.0
+    assert meta == {'method':'method','years':[2021]}
+
+
+def test_merge_tax_data_simple():
+    tgt = pd.DataFrame({'year':[2000,2001],'TAX_pct_GDP':[None,None]})
+    tax = pd.DataFrame({'year':[2000],'TAX_pct_GDP':[10.0]})
+    out, meta = merge_tax_data(tgt, tax)
+    assert out.loc[out['year']==2000,'TAX_pct_GDP'].iloc[0] == 10.0
+    assert meta is None
+
+
+def test_prepare_final_dataframe_drops_duplicates():
+    df = pd.DataFrame({'year':[2000,2000,2001],'a':[1,2,3],'b':[4,5,6]})
+    column_map = {'year':'Year','a':'A'}
+    out = prepare_final_dataframe(df, column_map)
+    assert list(out.columns) == ['Year','A']
+    assert len(out) == 2
+

--- a/china_data/tests/test_processor.py
+++ b/china_data/tests/test_processor.py
@@ -82,8 +82,9 @@ def test_project_capital_stock(monkeypatch):
         'I_USD_bn':[5.0,5.25]
     })
     projected = project_capital_stock(data, end_year=2019)
-    # Function currently returns None when insufficient information is provided
-    assert projected is None
+    assert isinstance(projected, pd.DataFrame)
+    assert 2019 in projected['year'].values
+    assert not projected.loc[projected['year'] == 2019, 'K_USD_bn'].isna().any()
 
 
 def test_project_human_capital_fallback(monkeypatch):

--- a/china_data/tests/test_utils.py
+++ b/china_data/tests/test_utils.py
@@ -1,0 +1,28 @@
+import os
+from china_data.utils import get_project_root, find_file, ensure_directory, get_output_directory
+from china_data.utils.path_constants import PACKAGE_DIR_NAME, OUTPUT_DIR_NAME
+
+
+def test_get_project_root_returns_existing_directory():
+    root = get_project_root()
+    assert os.path.isdir(root)
+    assert root.endswith('china-game-pheromind')
+
+
+def test_find_file_locates_known_file():
+    path = find_file('README.md', [PACKAGE_DIR_NAME])
+    assert path and path.endswith(os.path.join(PACKAGE_DIR_NAME, 'README.md'))
+
+
+def test_ensure_directory_creates_path(tmp_path):
+    new_dir = tmp_path / 'sub'
+    path = ensure_directory(str(new_dir))
+    assert os.path.isdir(path)
+
+
+def test_get_output_directory_exists():
+    out_dir = get_output_directory()
+    expected = os.path.join(get_project_root(), PACKAGE_DIR_NAME, OUTPUT_DIR_NAME)
+    assert out_dir == expected
+    assert os.path.isdir(out_dir)
+


### PR DESCRIPTION
## Summary
- add coverage tests for dataframe utility functions and path helpers
- fix `test_project_capital_stock` expectations

## Testing
- `pytest -q`